### PR TITLE
fix non-ascii character in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,11 @@ Installation
 
 To install pytest-instafail::
 
-    $ pip install pytest-instafail
+    $ pip install pytest-instafail
 
 Then run your tests with::
 
-    $ py.test --instafail
+    $ py.test --instafail
 
 Resources
 ---------


### PR DESCRIPTION
the non-ascii character 0xc2 lead to an install failure on one of my systems.
