### PR TITLE
pytest_collectreport: only rewrite line on tty

### DIFF
--- a/pytest_instafail.py
+++ b/pytest_instafail.py
@@ -46,7 +46,8 @@ class InstafailingTerminalReporter(TerminalReporter):
         # Show errors occurred during the collection instantly.
         TerminalReporter.pytest_collectreport(self, report)
         if report.failed:
-            self.rewrite("")  # erase the "collecting" message
+            if getattr(self, "isatty", True):
+                self.rewrite('')  # erase the "collecting"/"collected" message
             self.print_failure(report)
 
     def pytest_runtest_logreport(self, report):


### PR DESCRIPTION
Without this, you would end up with a \r (^M) in case collecting of tests
failed, and pytest's output is piped to a file.