### PR TITLE
Update test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
 *.pyc
+.cache/
 .tox/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
-  - pypy
 env:
-  - PYTEST=2.3.5
-  - PYTEST=2.4.2
-  - PYTEST=2.5.2
-  - PYTEST=2.6.1
+  matrix:
+    # Please use "tox --listenvs" to populate the build matrix below.
+    - TESTENV=py26-pytest29
+    - TESTENV=py27-pytest29
+    - TESTENV=py33-pytest29
+    - TESTENV=py34-pytest29
+    - TESTENV=py35-pytest29
+    - TESTENV=pypy-pytest29
+    - TESTENV=py26-pytest30
+    - TESTENV=py27-pytest30
+    - TESTENV=py33-pytest30
+    - TESTENV=py34-pytest30
+    - TESTENV=py35-pytest30
+    - TESTENV=pypy-pytest30
 install:
-  - pip install -q pytest==$PYTEST
-  - pip install -q -e .
+  - pip install -U tox
 script:
-  - py.test
+  - tox --recreate -e $TESTENV

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Changelog
 
 Here you can see the full list of changes between each pytest-instafail release.
 
+0.4.0 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Added support for Python 3.5
+- Dropped support for Python 3.2
+- Dropped support for pytest < 2.9
+
 0.3.0 (August 30, 2014)
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-instafail:
 
-- Python 2.6, 2.7, 3.2, 3.3, 3.4 or PyPy
-- pytest 2.3 or newer
+- Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 or PyPy
+- pytest 2.9 or newer
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=['pytest>=2.3'],
+    install_requires=['pytest>=2.9'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -29,9 +29,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]
 )

--- a/test_instafail.py
+++ b/test_instafail.py
@@ -258,7 +258,7 @@ class TestInstafailingTerminalReporter(object):
         child = testdir.spawn_pytest(' '.join(args))
         child.expect('>+ traceback >+')
 
-        assert 'E       assert 0' not in child.before
+        assert b'E       assert 0' not in child.before
 
         child.expect('(Pdb)')
         child.sendeof()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist =
+  py{26,27,33,34,35,py}-pytest{29,30}
 
 [testenv]
 deps =
     pexpect
+    pytest29: pytest~=2.9.2
+    pytest30: pytest~=3.0.2
     pytest-xdist
 commands = py.test {posargs}


### PR DESCRIPTION
* Add Python 3.5 to the build matrix.
* Add pytest 2.9 and 3.0 to the build matrix.
* Remove pytest < 2.9 from the build matrix.