### PR TITLE
Support -p no:terminal (fixes #12)

### DIFF
--- a/pytest_instafail.py
+++ b/pytest_instafail.py
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     if hasattr(config, 'slaveinput'):
         return  # xdist slave, we are already active on the master
-    if config.option.instafail:
+    if config.option.instafail and config.pluginmanager.hasplugin('terminalreporter'):
         # Get the standard terminal reporter plugin...
         standard_reporter = config.pluginmanager.getplugin('terminalreporter')
         instafail_reporter = InstafailingTerminalReporter(standard_reporter)


### PR DESCRIPTION
Fixes #12 
Check if standard terminal plugin exists. It happens is call `pytest -p no:terminal --instafail`