### PR TITLE
Add support for Python 3.9 and 3.10, drop EOL 2.7 and 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-instafail:
 
-- Python 2.7, 3.5+ or PyPy
-- pytest 2.9 or newer
+- Python 3.6+ or PyPy3
+- pytest 5 or newer
 
 Installation
 ------------

--- a/pytest_instafail.py
+++ b/pytest_instafail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 pytest_instafail
 ~~~~~~~~~~~~~~~~

--- a/pytest_instafail.py
+++ b/pytest_instafail.py
@@ -76,13 +76,11 @@ class InstafailingTerminalReporter(TerminalReporter):
                 self.write_line(line)
             else:
                 msg = self._getfailureheadline(report)
-                # "when" was unset before pytest 4.2 for collection errors.
-                when = getattr(report, "when", "collect")
-                if when == "collect":
+                if report.when == "collect":
                     msg = "ERROR collecting " + msg
-                elif when == "setup":
+                elif report.when == "setup":
                     msg = "ERROR at setup of " + msg
-                elif when == "teardown":
+                elif report.when == "teardown":
                     msg = "ERROR at teardown of " + msg
                 self.write_sep("_", msg)
                 if not self.config.getvalue("usepdb"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 addopts = --color=yes

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=['pytest>=2.9'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    install_requires=['pytest>=5'],
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -26,13 +26,13 @@ setup(
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]
 )

--- a/test_instafail.py
+++ b/test_instafail.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 pytest_plugins = "pytester"
 import pytest
 
 
-class Option(object):
+class Option:
     def __init__(self, verbose=False, quiet=False, n=None):
         self.verbose = verbose
         self.quiet = quiet
@@ -40,7 +38,7 @@ def option(request, n):
     }[request.param]
 
 
-class TestInstafailingTerminalReporter(object):
+class TestInstafailingTerminalReporter:
     def test_fail(self, testdir, option):
         testdir.makepyfile(
             """

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,10 @@
 [tox]
 envlist =
-  py{27,35,36,37,38,39,310,py,py3}-pytest{2,3,4,5,6}
+  py{36,37,38,39,310,py3}-pytest{5,6}
 
 [testenv]
 deps =
     pexpect
-    pytest2: pytest<3.0
-    pytest2: pytest-xdist<1.18.0
-    pytest3: pytest>3.0,<4.0
-    pytest3: pytest-xdist
-    pytest4: pytest>4.0,<5.0
-    pytest4: pytest-xdist
     pytest5: pytest>5.0,<6.0
     pytest5: pytest-xdist
     pytest6: pytest>6.0,<7.0


### PR DESCRIPTION
Followup to https://github.com/pytest-dev/pytest-instafail/pull/23.

Add support for Python 3.9 and 3.10.

The changelog says Python 2.7 was dropped in pytest-instafail 0.4.0 (May 19, 2018):

https://github.com/pytest-dev/pytest-instafail/blob/e37b081d23fa6bfa8471effc8d11c61a5518793a/CHANGES.rst#040-may-19-2018

This PR removes classifier and updates `python_requires` to avoid install for Python 2.7.

EOL Python 3.5 is also dropped, and as only pytest 5+ is tested, drop older pytest (version 5 was [released June 2019](https://pypi.org/project/pytest/5.0.0/)).
