### PR TITLE
Use pytest.hookimpl to configure hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog
 
 Here you can see the full list of changes between each pytest-instafail release.
 
+0.4.3 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Use ``pytest.hookimpl`` to configure hooks, avoiding a deprecation warning in
+  the upcoming pytest 7.2.0.
+
 0.4.2 (June 14, 2020)
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/pytest_instafail.py
+++ b/pytest_instafail.py
@@ -22,7 +22,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     if hasattr(config, 'workerinput'):
         return  # xdist worker, we are already active on the master


### PR DESCRIPTION
See
https://github.com/pytest-dev/pytest/pull/9118
https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers