### PR TITLE
Fix checks failing on PyPy 3.6 not found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["pypy-3.7", "pypy-3.8", "pypy-3.9", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         pytest-tox-version: ["pytest5", "pytest6"]
         include:
           # Add new variables to existing jobs
-          - {python-version: "pypy3", python-tox-version: "pypy3"}
+          - {python-version: "pypy-3.7", python-tox-version: "pypy37"}
+          - {python-version: "pypy-3.8", python-tox-version: "pypy38"}
+          - {python-version: "pypy-3.9", python-tox-version: "pypy39"}
           - {python-version: "3.6", python-tox-version: "py36"}
           - {python-version: "3.7", python-tox-version: "py37"}
           - {python-version: "3.8", python-tox-version: "py38"}
@@ -30,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38,39,310,py3}-pytest{5,6}
+  py{36,37,38,39,310,py37,py38,py39}-pytest{5,6}
 
 [testenv]
 deps =


### PR DESCRIPTION
Bump `actions/setup-python` to 4.3.0 and use more specific PyPy versions in the build.