### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["pypy-3.7", "pypy-3.8", "pypy-3.9", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["pypy-3.7", "pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10-dev"]
         pytest-tox-version: ["pytest5", "pytest6"]
         include:
           # Add new variables to existing jobs
           - {python-version: "pypy-3.7", python-tox-version: "pypy37"}
           - {python-version: "pypy-3.8", python-tox-version: "pypy38"}
           - {python-version: "pypy-3.9", python-tox-version: "pypy39"}
-          - {python-version: "3.6", python-tox-version: "py36"}
           - {python-version: "3.7", python-tox-version: "py37"}
           - {python-version: "3.8", python-tox-version: "py38"}
           - {python-version: "3.9", python-tox-version: "py39"}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,12 @@ Changelog
 
 Here you can see the full list of changes between each pytest-instafail release.
 
-0.4.3 (not yet released)
+0.5.0 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Use ``pytest.hookimpl`` to configure hooks, avoiding a deprecation warning in
   the upcoming pytest 7.2.0.
+- Dropped support for Python 3.6.
 
 0.4.2 (June 14, 2020)
 ^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-instafail:
 
-- Python 3.6+ or PyPy3
+- Python 3.7+ or PyPy3
 - pytest 5 or newer
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=['pytest>=5'],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -28,7 +28,6 @@ setup(
         'Topic :: Utilities',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38,39,310,py37,py38,py39}-pytest{5,6}
+  py{37,38,39,310,py37,py38,py39}-pytest{5,6}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.6 reached its end-of-life on Dec 23rd, 2021.