### PR TITLE
Update Github actions to use Environment Files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache
         uses: actions/cache@v3


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Upgrade it to use Environment Files.